### PR TITLE
Standardize Installation 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ echo [*] Staging process...
 mkdir ~/.MK01-OnlyRAT
 cd ..
 mv MK01-OnlyRAT/* ~/.MK01-OnlyRAT
-#rm -rf MK01-OnlyRAT
+rm -rf MK01-OnlyRAT
 cd ~/.MK01-OnlyRAT
 echo [+] Completed
 

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ echo [*] Staging process...
 mkdir ~/.MK01-OnlyRAT
 cd ..
 mv MK01-OnlyRAT/* ~/.MK01-OnlyRAT
-rm -rf MK01-OnlyRAT
+#rm -rf MK01-OnlyRAT
 cd ~/.MK01-OnlyRAT
 echo [+] Completed
 
@@ -18,13 +18,13 @@ sudo apt-get install sshpass
 sudo apt-get install python3
 echo [+] Completed
 
-# set up alias workflow
-echo [*] Setting up alias...
-echo "alias onlyrat=\"python3 $(pwd)/main.py\"" >> ~/.bashrc
-echo "alias onlyrat=\"python3 $(pwd)/main.py\"" >> ~/.zshrc
+# install to PATH
+echo [*] Installing to /usr/local/bin...
+    # Create a wrapper file in /usr/local/bin to call main.py
+sudo touch /usr/local/bin/onlyrat
+echo -e "#!/bin/bash\npython3 ~/.MK01-OnlyRAT/main.py \"\$@\"" | sudo tee /usr/local/bin/onlyrat
 echo [+] Completed
 
 # clean up
 echo [+] Installation Completed
-echo "- please restart your terminal"
 echo "- type 'onlyrat' to launch OnlyRat"

--- a/install.sh
+++ b/install.sh
@@ -22,10 +22,10 @@ echo [+] Completed
 echo [*] Installing to /usr/local/bin...
 # Create a wrapper file in /usr/local/bin to call main.py
 sudo touch /usr/local/bin/onlyrat
-echo -e "#!/bin/bash\npython3 ~/.MK01-OnlyRAT/main.py \"\$@\"" | sudo tee /usr/local/bin/onlyrat 
+printf "#!/bin/bash\npython3 ~/.MK01-OnlyRAT/main.py \"\$@\"" | sudo tee /usr/local/bin/onlyrat 
 sudo chmod +x /usr/local/bin/onlyrat
 echo [+] Completed
 
 # clean up
 echo [+] Installation Completed
-echo -e"\n- Type 'onlyrat' to launch OnlyRat"
+printf "\n- Type 'onlyrat' to launch OnlyRat\n"

--- a/install.sh
+++ b/install.sh
@@ -18,13 +18,14 @@ sudo apt-get install sshpass
 sudo apt-get install python3
 echo [+] Completed
 
-# install to PATH
+# Install 
 echo [*] Installing to /usr/local/bin...
-    # Create a wrapper file in /usr/local/bin to call main.py
+# Create a wrapper file in /usr/local/bin to call main.py
 sudo touch /usr/local/bin/onlyrat
-echo -e "#!/bin/bash\npython3 ~/.MK01-OnlyRAT/main.py \"\$@\"" | sudo tee /usr/local/bin/onlyrat
+echo -e "#!/bin/bash\npython3 ~/.MK01-OnlyRAT/main.py \"\$@\"" | sudo tee /usr/local/bin/onlyrat 
+sudo chmod +x /usr/local/bin/onlyrat
 echo [+] Completed
 
 # clean up
 echo [+] Installation Completed
-echo "- type 'onlyrat' to launch OnlyRat"
+echo -e"\n- Type 'onlyrat' to launch OnlyRat"

--- a/main.py
+++ b/main.py
@@ -250,6 +250,7 @@ def remove():
     # delete OnlyRAT
     if option == "y":
         os.system("rm -rf ~/.MK01-OnlyRAT")
+        os.system("sudo rm /usr/local/bin/onlyrat")
 
     # cancel
     if option == "n":


### PR DESCRIPTION
# Current
The installation.sh script moves the program files to the Home directory and creates an alias in .bashrc and .zshrc.
This is not standard and can make things complex for a user that is not familiar with this. If installed many times the alias will be appended to the rc files.
# This implementation
With this implementation the program files will still be moved to the users home directory but instead of appending an alias to the rc files we just create a wrapper script in /usr/local/bin/ that points to main.py in ~/.MK01-OnlyRAT/. 
Because /usr/local/bin/ is already in $PATH there is no need to add aliases.
## Uninstall
Previously there was nothing in the uninstall function to remove the aliases. The update to this function reflects the installation change and will remove the wrapper script from /usr/local/bin/